### PR TITLE
Add delegation threshold slider and config handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ COPY --chown=agent:agent . .
 
 # Create default config if it doesn't exist
 RUN if [ ! -f /app/agent_memory/static_config.json ]; then \
-    echo '{"mode":"local","local_model_path":"/app/models/tinyllama.gguf","system_prompt_file":"system_prompt.txt","remote_dev":{"user":"user","ip":"192.168.1.100","port":22},"logging":{"level":"INFO","max_log_size_mb":50,"max_log_days":30},"memory":{"faiss_index_path":"/app/agent_memory/embeddings.faiss","recall_log_path":"/app/agent_memory/recall_log.jsonl"},"system_info":{"hostname":"diagnostic-agent","platform":"raspberry-pi","last_updated":"2025-07-30T00:00:00Z"}}' > /app/agent_memory/static_config.json; \
+    echo '{"mode":"local","local_model_path":"/app/models/tinyllama.gguf","system_prompt_file":"system_prompt.txt","remote_dev":{"user":"user","ip":"192.168.1.100","port":22},"logging":{"level":"INFO","max_log_size_mb":50,"max_log_days":30},"memory":{"faiss_index_path":"/app/agent_memory/embeddings.faiss","recall_log_path":"/app/agent_memory/recall_log.jsonl"},"routing":{"delegation_threshold":0.65},"system_info":{"hostname":"diagnostic-agent","platform":"raspberry-pi","last_updated":"2025-07-30T00:00:00Z"}}' > /app/agent_memory/static_config.json; \
     fi
 
 # Environment variables

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -39,7 +39,7 @@ RUN mkdir -p /app/agent_memory /app/agent_memory/archived_sessions /app/logs && 
 
 # Ensure static_config.json exists
 RUN if [ ! -f /app/agent_memory/static_config.json ]; then \
-    echo '{"mode":"local","local_model_path":"/app/models/tinyllama.gguf","system_prompt_file":"system_prompt.txt","remote_dev":{"user":"user","ip":"192.168.1.100","port":22},"logging":{"level":"INFO","max_log_size_mb":50,"max_log_days":30},"memory":{"faiss_index_path":"/app/agent_memory/embeddings.faiss","recall_log_path":"/app/agent_memory/recall_log.jsonl"},"system_info":{"hostname":"diagnostic-agent","platform":"raspberry-pi","last_updated":"2025-07-30T00:00:00Z"}}' > /app/agent_memory/static_config.json; \
+    echo '{"mode":"local","local_model_path":"/app/models/tinyllama.gguf","system_prompt_file":"system_prompt.txt","remote_dev":{"user":"user","ip":"192.168.1.100","port":22},"logging":{"level":"INFO","max_log_size_mb":50,"max_log_days":30},"memory":{"faiss_index_path":"/app/agent_memory/embeddings.faiss","recall_log_path":"/app/agent_memory/recall_log.jsonl"},"routing":{"delegation_threshold":0.65},"system_info":{"hostname":"diagnostic-agent","platform":"raspberry-pi","last_updated":"2025-07-30T00:00:00Z"}}' > /app/agent_memory/static_config.json; \
     fi
 
 # Create non-root user

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -60,7 +60,7 @@ RUN mkdir -p /app/agent_memory && \
 
 # Ensure static_config.json exists with correct structure
 RUN if [ ! -f /app/agent_memory/static_config.json ]; then \
-    echo '{"mode":"local","local_model_path":"/app/models/tinyllama.gguf","system_prompt_file":"system_prompt.txt","remote_dev":{"user":"user","ip":"192.168.1.100","port":22},"logging":{"level":"INFO","max_log_size_mb":50,"max_log_days":30},"memory":{"faiss_index_path":"/app/agent_memory/embeddings.faiss","recall_log_path":"/app/agent_memory/recall_log.jsonl"},"system_info":{"hostname":"diagnostic-agent","platform":"raspberry-pi","last_updated":"2025-07-30T00:00:00Z"}}' > /app/agent_memory/static_config.json; \
+    echo '{"mode":"local","local_model_path":"/app/models/tinyllama.gguf","system_prompt_file":"system_prompt.txt","remote_dev":{"user":"user","ip":"192.168.1.100","port":22},"logging":{"level":"INFO","max_log_size_mb":50,"max_log_days":30},"memory":{"faiss_index_path":"/app/agent_memory/embeddings.faiss","recall_log_path":"/app/agent_memory/recall_log.jsonl"},"routing":{"delegation_threshold":0.65},"system_info":{"hostname":"diagnostic-agent","platform":"raspberry-pi","last_updated":"2025-07-30T00:00:00Z"}}' > /app/agent_memory/static_config.json; \
     fi
 
 # Create a non-root user for security and add to docker group

--- a/agent_memory/static_config.json
+++ b/agent_memory/static_config.json
@@ -16,6 +16,9 @@
     "faiss_index_path": "/app/agent_memory/embeddings.faiss",
     "recall_log_path": "/app/agent_memory/recall_log.jsonl"
   },
+  "routing": {
+    "delegation_threshold": 0.65
+  },
   "system_info": {
     "hostname": "diagnostic-agent",
     "platform": "raspberry-pi",

--- a/autonomic_dispatcher.py
+++ b/autonomic_dispatcher.py
@@ -23,7 +23,9 @@ try:
 except FileNotFoundError:
     # Create default config if it doesn't exist
     config = {
-        "delegation_threshold": 0.65,
+        "routing": {
+            "delegation_threshold": 0.65
+        },
         "dev_machine": {
             "host": "picklegate.ddns.net",
             "port": 2222,
@@ -36,7 +38,7 @@ except FileNotFoundError:
         json.dump(config, f, indent=2)
     logger.info(f"Created default config at {config_path}")
 
-THRESHOLD = config.get("delegation_threshold", 0.65)
+THRESHOLD = config.get("routing", {}).get("delegation_threshold", 0.65)
 DEV_HOST = config.get("dev_machine", {}).get("host", "picklegate.ddns.net")
 DEV_PORT = config.get("dev_machine", {}).get("port", 2222)
 DEV_USER = config.get("dev_machine", {}).get("user", "castlebravo")

--- a/index.html
+++ b/index.html
@@ -37,6 +37,12 @@
       padding: 0.5em 1em;
       cursor: pointer;
     }
+    .slider-container {
+      margin-top: 1em;
+    }
+    input[type="range"] {
+      width: 100%;
+    }
     .status {
       font-size: 0.9em;
       margin-bottom: 1em;
@@ -95,6 +101,11 @@
     <h2>>_ Diagnostic Journalist</h2>
     <div class="status" id="status">[Checking connection status...]</div>
 
+    <div class="slider-container">
+      <label for="threshold">Delegation Threshold: <span id="thresholdValue">0.65</span></label>
+      <input type="range" id="threshold" min="0" max="1" step="0.01">
+    </div>
+
     <div class="prompt">
       <input type="text" id="command" placeholder="Enter command here...">
       <button onclick="sendCommand()">Send</button>
@@ -123,7 +134,21 @@
       } catch {
         document.getElementById('status').textContent = '[Status: CONNECTION ERROR]';
       }
-    }async function sendCommand() {
+    }
+
+    async function loadThreshold() {
+      try {
+        const res = await fetch('/config?key=routing.delegation_threshold');
+        const json = await res.json();
+        const val = parseFloat(json.value ?? 0.65);
+        document.getElementById('threshold').value = val;
+        document.getElementById('thresholdValue').textContent = val.toFixed(2);
+      } catch {
+        // ignore errors
+      }
+    }
+
+    async function sendCommand() {
       const cmd = document.getElementById('command').value;
       if (!cmd.trim()) return;
       
@@ -188,7 +213,9 @@
     async function toggleSSH() {
       await fetch('/toggle-ssh', { method: 'POST' });
       updateStatus();
-    }    async function toggleLog() {
+    }
+
+    async function toggleLog() {
       const log = document.getElementById('logViewer');
       if (log.style.display === 'none') {
         try {
@@ -216,8 +243,23 @@
       }
     });
 
+    document.getElementById('threshold').addEventListener('input', async function(e) {
+      const val = parseFloat(e.target.value);
+      document.getElementById('thresholdValue').textContent = val.toFixed(2);
+      try {
+        await fetch('/config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: 'routing.delegation_threshold', value: val })
+        });
+      } catch (err) {
+        console.error('Failed to update threshold', err);
+      }
+    });
+
     setInterval(updateStatus, 15000);
     updateStatus();
+    loadThreshold();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add delegation threshold slider to the frontend with live updates
- sanitize and persist threshold updates on `/config`, logging changes
- store `routing.delegation_threshold` in static config and include in Docker defaults

## Testing
- `python -m py_compile autonomic_dispatcher.py web_agent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891450be1988328ac4eaaa54a101498